### PR TITLE
[webhook-slash] Set content-type header

### DIFF
--- a/webhook-slash/Cargo.toml
+++ b/webhook-slash/Cargo.toml
@@ -7,11 +7,11 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = { version = "1", features = ["full"] }
-hyper = { version = "0.14", features = ["full"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+hyper = { version = "0.14", features = ["server", "http1", "runtime"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-twilight-model = { version = "0.5.0" }
+twilight-model = { version = "0.6" }
 tracing-subscriber = "0.2"
 hex = "0.4"
 once_cell = "1.4.1"

--- a/webhook-slash/src/main.rs
+++ b/webhook-slash/src/main.rs
@@ -8,6 +8,7 @@ use twilight_model::application::{
 };
 
 use hyper::{
+    header::CONTENT_TYPE,
     http::StatusCode,
     service::{make_service_fn, service_fn},
     Body, Method, Request, Response, Server,
@@ -75,14 +76,13 @@ where
         .is_err()
     {
         return Ok(Response::builder()
-            .status(StatusCode::FORBIDDEN)
+            .status(StatusCode::UNAUTHORIZED)
             .body(Body::empty())?);
     }
 
     // Deserialize the body into a interaction.
     let interaction = serde_json::from_slice::<Interaction>(&whole_body)?;
 
-    
     match interaction {
         // Return a Pong if a Ping is received.
         Interaction::Ping(_) => {
@@ -92,6 +92,7 @@ where
 
             Ok(Response::builder()
                 .status(StatusCode::OK)
+                .header(CONTENT_TYPE, "application/json")
                 .body(json.into())?)
         }
         // Respond to a slash command.
@@ -100,10 +101,11 @@ where
             let response = f(interaction).await?;
 
             // Serialize the response and return it back to discord.
-            
+
             let json = serde_json::to_vec(&response)?;
 
             Ok(Response::builder()
+                .header(CONTENT_TYPE, "application/json")
                 .status(StatusCode::OK)
                 .body(json.into())?)
         }


### PR DESCRIPTION
Set the content header to `application/json` as Discord otherwise
would fail the response.  Also changes it to respond with the correct
status code and updates the dependencies and minimizes the used
features.